### PR TITLE
Ensure that directory ends with /

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -70,6 +70,8 @@
 
 (defun ag/search (string directory)
   "Run ag searching for the literal STRING given in DIRECTORY."
+  (unless (string-match "/$" directory)
+    (setq directory (concat directory "/")))
   (let ((default-directory directory))
     (compilation-start
      (ag/s-join " "


### PR DESCRIPTION
Without this doing something like the following:

(ag/search "emacs" "/etc/emacs")

Will search in /etc instead of /etc/emacs but default-directory will be set to /etc/emacs and everything gets confused.
