### PR TITLE
Highlight search hits as info, not warnings or errors

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -73,7 +73,7 @@ This requires the ag command to support --color-match, which is only in v0.14+"
 (define-compilation-mode ag-mode "Ag"
   "Ag results compilation mode"
   (let ((smbl  'compilation-ag-nogroup)
-        (pttrn '("^\\([^:\n]+?\\):\\([0-9]+\\):\\([0-9]+\\):" 1 2 3)))
+        (pttrn '("^\\([^:\n]+?\\):\\([0-9]+\\):\\([0-9]+\\):" 1 2 3 0)))
     (set (make-local-variable 'compilation-error-regexp-alist) (list smbl))
     (set (make-local-variable 'compilation-error-regexp-alist-alist) (list (cons smbl pttrn))))
   (add-hook 'compilation-filter-hook 'ag-filter nil t))


### PR DESCRIPTION
This makes the results a little nicer, IMO, and more consistent with those output by the commands in `grep.el`.

Cheers,

-Steve
