### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ your searches:
 ### Using with Projectile
 
 [Projectile](https://github.com/bbatsov/projectile) supports ag.el. If
-you have Projectile installed, `C-c p A` runs `ag` on your project.
+you have Projectile installed, `C-c p A` runs `ag-regexp` on your project.
 
 ### Customising the project root
 


### PR DESCRIPTION
Projectile's `C-c A` by default is bound to `ag-regexp` as you can see here https://github.com/bbatsov/projectile/blob/b1fb903530def09d815b359524d16edb099f5322/projectile.el#L1075
