### PR TITLE
Fix command for ag-dired-regexp

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -391,7 +391,7 @@ See also `find-dired'."
          (buffer-name (if ag-reuse-buffers
                           "*ag dired*"
                         (format "*ag dired pattern:%s dir:%s*" regexp dir)))
-         (cmd (concat "ag --nocolor -g '" regexp "' " dir " | grep -v '^$' | xargs -I {} ls " dired-listing-switches " {} &")))
+         (cmd (concat "ag --nocolor -g '" regexp "' '" dir "' | grep -v '^$' | xargs -I {} ls " dired-listing-switches " {} ")))
     (with-current-buffer (get-buffer-create buffer-name)
       (switch-to-buffer (current-buffer))
       (widen)


### PR DESCRIPTION
It used to work well, but now it somehow doesn't work if command executed asynchronously (with '&').
I've checked the problem on the following two environments.
- Emacs 24.3.1, MacOSX 10.8.5, ag 0.22.0
- Emacs 24.3.1, Ubuntu 14.04,  ag 0.19.2

And one more, wrapping `dir` path with quotes for a path includes spaces.

Could you confirm and pull this?
