### PR TITLE
Quote the directory and the xargs input

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -424,7 +424,10 @@ See also `find-dired'."
          (buffer-name (if ag-reuse-buffers
                           "*ag dired*"
                         (format "*ag dired pattern:%s dir:%s*" regexp dir)))
-         (cmd (concat ag-executable " --nocolor -g '" regexp "' " dir " | grep -v '^$' | xargs -I {} ls " dired-listing-switches " {} &")))
+         (cmd (concat "ag --nocolor -g '" regexp "' "
+                      (shell-quote-argument dir)
+                      " | grep -v '^$' | sed s/\\'/\\\\\\\\\\'/ | xargs -I '{}' ls "
+                      dired-listing-switches " '{}' &")))
     (with-current-buffer (get-buffer-create buffer-name)
       (switch-to-buffer (current-buffer))
       (widen)


### PR DESCRIPTION
We need to quote both the directory and the output from `ag`, beacuse `xargs` is stupid.

When ag supports `-0` argument, we can simply pipe into `xargs -0`, but until then we need to do the quoting manually.

`sed` replaces `'` with `\'`, then we wrap the entire file name with `' '`.
