### PR TITLE
Revert should call `ag-dired-regexp` to avoid quoting already quoted regexp

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -453,7 +453,7 @@ See also `find-dired'."
       (set (make-local-variable 'dired-sort-inhibit) t)
       (set (make-local-variable 'revert-buffer-function)
            `(lambda (ignore-auto noconfirm)
-              (ag-dired ,orig-dir ,regexp)))
+              (ag-dired-regexp ,orig-dir ,regexp)))
       (if (fboundp 'dired-simple-subdir-alist)
           (dired-simple-subdir-alist)
         (set (make-local-variable 'dired-subdir-alist)


### PR DESCRIPTION
If we call `ag-dired` from `ag-dired-regexp`, the potentially quoted search string will be quoted again, then passed to `ag-dired-regexp`. This leads to incorrect search string and broken revert.
