### PR TITLE
Fix removal of default directory in dired filter

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -292,8 +292,8 @@ roots."
                 (beginning-of-line)
 
                 ;; Remove occurrences of default-directory.
-                (while (search-forward default-directory nil t)
-                  (replace-match "" nil t))
+                (while (search-forward (concat " " default-directory) nil t)
+                  (replace-match " " nil t))
 
                 (goto-char (point-max))
                 (if (search-backward "\n" (process-mark proc) t)


### PR DESCRIPTION
In case `default-directory` is `/` or some substring occuring later in the file name, this will incorrectly be removed in the filter.  We need to only remove it when it is preceeded by space (i.e. at the start of the "filename" column). Granted, this also isn't completely fool-proof, but a situation where that could be a problem will hardly ever occur.

As of now I don't know a better solution.
