### PR TITLE
Use completing-read instead of ido-completing-read

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -574,8 +574,8 @@ This function is called from `compilation-filter-hook'."
   (let* ((all-types-with-extensions (ag/get-supported-types))
          (all-types (mapcar 'car all-types-with-extensions))
          (file-type
-          (ido-completing-read "Select file type: "
-                               (append '("custom (provide a PCRE regex)") all-types)))
+          (completing-read "Select file type: "
+                           (append '("custom (provide a PCRE regex)") all-types)))
          (file-type-extensions
           (cdr (assoc file-type all-types-with-extensions))))
     (if file-type-extensions


### PR DESCRIPTION
The built-in completing-read can be overridden by ido-ubiquitous-mode
and helm-mode, so it seems preferable to not assume that ido should
always handle this prompt.
