### PR TITLE
Remove hard evil dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,7 +2,3 @@
 (source melpa)
 
 (package-file "ag.el")
-
-(depends-on "dash")
-(depends-on "s")
-(depends-on "evil")

--- a/ag.el
+++ b/ag.el
@@ -584,13 +584,5 @@ This function is called from `compilation-filter-hook'."
             (read-from-minibuffer "Filenames which match PCRE: "
                                   (ag/buffer-extension-regex))))))
 
-;; Use hjkl for motion if the user uses evil-mode.
-;; See https://github.com/Wilfred/ag.el/issues/72
-(eval-after-load 'evil
-  `(progn
-     (eval-when-compile (require 'evil-core))
-     (add-to-list 'evil-motion-state-modes 'ag-mode)
-     (evil-add-hjkl-bindings ag-mode-map 'motion)))
-
 (provide 'ag)
 ;;; ag.el ends here


### PR DESCRIPTION
Assuming we follow @lunaryorn's suggestion in #82 to move the hjkl stuff to `evil-integration`, this would be the necessary changes. And 93bc423 is a good idea in any case.