### PR TITLE
Don't fail if we have no evil

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -588,7 +588,7 @@ This function is called from `compilation-filter-hook'."
 ;; See https://github.com/Wilfred/ag.el/issues/72
 (eval-after-load 'evil
   `(progn
-     (eval-when-compile (require 'evil-core))
+     (eval-when-compile (require 'evil-core nil t))
      (add-to-list 'evil-motion-state-modes 'ag-mode)
      (evil-add-hjkl-bindings ag-mode-map 'motion)))
 


### PR DESCRIPTION
`ag.el` currently fails compiling if there is no `evil-core` package.

My patch allows `ag.el` to skip the evil stuff if `(require 'evil-core)` fails at compile time.

I admit, omitting the evil stuff if we have no evil at compile-time is not very graceful, but it's surely nicer then failing the compilation if user has no evil.