### PR TITLE
Support for ag grouped output

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -215,16 +215,16 @@ If REGEXP is non-nil, treat STRING as a regular expression."
                     "--color-path" "1;32")
                   arguments))
     (if ag-group-matches
-        (setq arguments (append '("--group") arguments))
-      (setq arguments (append '("--nogroup") arguments)))
+        (setq arguments (cons "--group" arguments))
+      (setq arguments (cons "--nogroup" arguments)))
     (when ag-context-lines
       (let ((ctx (number-to-string ag-context-lines)))
-        (setq arguments (append (list "-A" ctx "-B" ctx) arguments))))
+        (setq arguments (append `("-A" ,ctx "-B" ,ctx) arguments))))
     (unless regexp
       (setq arguments (cons "--literal" arguments)))
     (when (eq system-type 'windows-nt)
       ;; Use --vimgrep to work around issue #97 on Windows.
-      (setq arguments (append '("--vimgrep") arguments)))
+      (setq arguments (cons "--vimgrep" arguments)))
     (when (char-or-string-p file-regex)
       (setq arguments (append `("--file-search-regex" ,file-regex) arguments)))
     (when file-type

--- a/ag.el
+++ b/ag.el
@@ -50,7 +50,7 @@
   :group 'ag)
 
 (defcustom ag-arguments
-  (list "--smart-case" "--stats" "--")
+  (list "--smart-case" "--stats")
   "Additional arguments passed to ag.
 
 Ag.el internally uses --column, --line-number and --color
@@ -210,6 +210,10 @@ If REGEXP is non-nil, treat STRING as a regular expression."
   (let ((default-directory (file-name-as-directory directory))
         (arguments ag-arguments)
         (shell-command-switch "-c"))
+    ;; Add double dashes at the end of command line if not specified in
+    ;; ag-arguments.
+    (unless (equal (car (last arguments)) "--")
+      (setq arguments (append arguments '("--"))))
     (setq arguments
           (append '("--line-number" "--column" "--color" "--color-match" "30;43"
                     "--color-path" "1;32")

--- a/ag.el
+++ b/ag.el
@@ -221,9 +221,6 @@ If REGEXP is non-nil, treat STRING as a regular expression."
     (if ag-group-matches
         (setq arguments (cons "--group" arguments))
       (setq arguments (cons "--nogroup" arguments)))
-    (when ag-context-lines
-      (let ((ctx (number-to-string ag-context-lines)))
-        (setq arguments (append `("-A" ,ctx "-B" ,ctx) arguments))))
     (unless regexp
       (setq arguments (cons "--literal" arguments)))
     (when (eq system-type 'windows-nt)
@@ -233,8 +230,10 @@ If REGEXP is non-nil, treat STRING as a regular expression."
       (setq arguments (append `("--file-search-regex" ,file-regex) arguments)))
     (when file-type
       (setq arguments (cons (format "--%s" file-type) arguments)))
-    (when (integerp current-prefix-arg)
-      (setq arguments (cons (format "--context=%d" (abs current-prefix-arg)) arguments)))
+    (if (integerp current-prefix-arg)
+        (setq arguments (cons (format "--context=%d" (abs current-prefix-arg)) arguments))
+      (when ag-context-lines
+        (setq arguments (cons (format "--context=%d" ag-context-lines) arguments))))
     (when ag-ignore-list
       (setq arguments (append (ag/format-ignore ag-ignore-list) arguments)))
     (unless (file-exists-p default-directory)

--- a/ag.el
+++ b/ag.el
@@ -628,7 +628,10 @@ This function is called from `compilation-filter-hook'."
         (when ag-group-matches
           (goto-char beg)
           (while (re-search-forward "\033\\[1;32m\\(.*\\)\033\\[0m\033\\[K" end 1)
-            (replace-match (concat "File: " (match-string 1)) t t)))
+            (replace-match
+             (concat "File: " (propertize (match-string 1) 'face nil 'font-lock-face
+                                          'compilation-info))
+             t t)))
         ;; Delete all remaining escape sequences
         (goto-char beg)
         (while (re-search-forward "\033\\[[0-9;]*[mK]" end 1)

--- a/ag.el
+++ b/ag.el
@@ -62,6 +62,11 @@ print line numbers when the input is a stream."
   :type '(repeat (string))
   :group 'ag)
 
+(defcustom ag-context-lines nil
+  "Number of context lines to include before and after a matching line."
+  :type 'integer
+  :group 'ag)
+
 (defcustom ag-group-matches nil
   "Group matches inn the same file together.
 
@@ -212,6 +217,9 @@ If REGEXP is non-nil, treat STRING as a regular expression."
     (if ag-group-matches
         (setq arguments (append '("--group") arguments))
       (setq arguments (append '("--nogroup") arguments)))
+    (when ag-context-lines
+      (let ((ctx (number-to-string ag-context-lines)))
+        (setq arguments (append (list "-A" ctx "-B" ctx) arguments))))
     (unless regexp
       (setq arguments (cons "--literal" arguments)))
     (when (eq system-type 'windows-nt)

--- a/ag.el
+++ b/ag.el
@@ -55,7 +55,7 @@
 
 Ag.el internally uses --column, --line-number and --color
 options (with specific colors) to match groups, so options
-specifid here should no contraddict them.
+specified here should no contraddict them.
 
 --line-number is required on Windows, as otherwise ag will not
 print line numbers when the input is a stream."


### PR DESCRIPTION
This adds support to match file/line/column in the compile filter with ag --grouped output, which can be toggled setting 'ag-group-matches'.

It also adds an 'ag-context-lines' custom for adding context to the match, without the need to change ag-arguments.