### PR TITLE
Slightly more intuitive ag-reuse-buffers behavior

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -163,7 +163,8 @@ different window, according to `ag-reuse-window'."
 (defun ag/buffer-name (search-string directory regexp)
   "Return a buffer name formatted according to ag.el conventions."
   (cond
-   (ag-reuse-buffers "*ag search*")
+   (ag-reuse-buffers
+    (if (eq major-mode 'ag-mode) (buffer-name) "*ag search*"))
    (regexp (format "*ag search regexp:%s dir:%s*" search-string directory))
    (:else (format "*ag search text:%s dir:%s*" search-string directory))))
 


### PR DESCRIPTION
- When current mode is ag-mode and ag-reuse-buffers is non-nil,
  reuse current buffer, else use/create `*ag search*` buffer.
  Allows multiple renamed ag-mode buffers to have (recompile)
  run on them.

This is very helpful behavior when you have multiple ag results buffers open, and need to re-run ag on them from time to time, but don't want to clobber `*ag search*`.