### PR TITLE
Highlight match in ag-search Buffer on Windows

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -45,7 +45,7 @@
   :group 'ag)
 
 (defcustom ag-arguments
-  (list "--line-number" "--smart-case" "--nogroup" "--column" "--stats" "--")
+  (list "--line-number" "--vimgrep" "--smart-case" "--nogroup" "--column" "--stats" "--")
   "Default arguments passed to ag.
 
 Ag.el requires --nogroup and --column, so we recommend you add any

--- a/ag.el
+++ b/ag.el
@@ -45,7 +45,7 @@
   :group 'ag)
 
 (defcustom ag-arguments
-  (list "--line-number" "--vimgrep" "--smart-case" "--nogroup" "--column" "--stats" "--")
+  (list "--line-number" "--smart-case" "--nogroup" "--column" "--stats" "--")
   "Default arguments passed to ag.
 
 Ag.el requires --nogroup and --column, so we recommend you add any


### PR DESCRIPTION
When we use `--vimgrep` _ag_ doesn't output escape sequences. This PR allows to highlight matches in `ag-search` buffer when `--vimgrep` option is used. Using `--vimgrep` is necessary on Windows, so without this change Windows users will not have highlighting of the matches.
