### PR TITLE
cygwin emacs version in windows have same problem as issue #97

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -223,7 +223,7 @@ If REGEXP is non-nil, treat STRING as a regular expression."
       (setq arguments (cons "--nogroup" arguments)))
     (unless regexp
       (setq arguments (cons "--literal" arguments)))
-    (when (eq system-type 'windows-nt)
+    (when (or (eq system-type 'windows-nt) (eq system-type 'cygwin))
       ;; Use --vimgrep to work around issue #97 on Windows.
       (setq arguments (cons "--vimgrep" arguments)))
     (when (char-or-string-p file-regex)


### PR DESCRIPTION
ag buffer have no filenames in cygwin's emacs 

OS: win10
emacs: emacs 24.5.1 compiled in cygwin
ag: master