### PR TITLE
Use variable `insert-directory-program` instead of hard coding `ls`

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -541,7 +541,8 @@ See also `find-dired'."
                         (format "*ag dired pattern:%s dir:%s*" regexp dir)))
          (cmd (concat ag-executable " --nocolor -g '" regexp "' "
                       (shell-quote-argument dir)
-                      " | grep -v '^$' | sed s/\\'/\\\\\\\\\\'/ | xargs -I '{}' ls "
+                      " | grep -v '^$' | sed s/\\'/\\\\\\\\\\'/ | xargs -I '{}' "
+                      insert-directory-program " "
                       dired-listing-switches " '{}' &")))
     (with-current-buffer (get-buffer-create buffer-name)
       (switch-to-buffer (current-buffer))


### PR DESCRIPTION
Not an emacs expert, but would it be better to use the variable `insert-directory-program` defined in files.el (part of emacs itself)?

My use case for this is that I customise `insert-directory-program` to something other than `ls`, namely `gls` (i.e. GNU ls).

Thanks!