### PR TITLE
Use smart case (-S) for ag-dired and friends

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -539,7 +539,7 @@ See also `find-dired'."
          (buffer-name (if ag-reuse-buffers
                           "*ag dired*"
                         (format "*ag dired pattern:%s dir:%s*" regexp dir)))
-         (cmd (concat ag-executable " --nocolor -g '" regexp "' "
+         (cmd (concat ag-executable " --nocolor -S -g '" regexp "' "
                       (shell-quote-argument dir)
                       " | grep -v '^$' | sed s/\\'/\\\\\\\\\\'/ | xargs -I '{}' "
                       insert-directory-program " "


### PR DESCRIPTION
This will be consistent with how the regular text ag search works.  It has to be enabled manually with `-g` to take effect on ag 0.31 and before (has no effect on 0.32+)

(I've had this in my personal fork for years and never figured it wasn't pushed upstream until I moved to this new computer :blush:)