### PR TITLE
Document winnow.el as an extension to ag.el

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -25,6 +25,14 @@ simply run ``wgrep-change-to-wgrep-mode`` and edit the ``*ag*``
 buffer. Press ``C-x C-s`` when you're done to make the changes to
 buffers.
 
+Focusing and filtering the results
+----------------------------------
+
+`winnow <https://github.com/dgtized/winnow.el>`_ can be used to focus or filter
+the results from ag. With the minor mode enabled, ``x`` excludes unwanted
+results, and ``m`` selects only the lines that match.
+
+
 Writing Your Own
 ----------------
 


### PR DESCRIPTION
I wrote winnow.el to filter and focus ag.el results (like if I'm searching on one keyword and want to remove tests or files from a particular language). So it seems appropriate to document it as an extension. Hopefully it helps others!