### PR TITLE
Fix concatenation of ag-dired arguments.

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -545,7 +545,7 @@ See also `find-dired'."
          (buffer-name (if ag-reuse-buffers
                           "*ag dired*"
                         (format "*ag dired pattern:%s dir:%s*" regexp dir)))
-         (cmd (concat ag-executable " " (string-join ag-dired-arguments " ") " -g '" regexp "' "
+         (cmd (concat ag-executable " " (combine-and-quote-strings ag-dired-arguments " ") " -g '" regexp "' "
                       (shell-quote-argument dir)
                       " | grep -v '^$' | sed s/\\'/\\\\\\\\\\'/ | xargs -I '{}' "
                       insert-directory-program " "


### PR DESCRIPTION
Fix for #143 

Uses `combine-and-quote-strings` described [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Shell-Arguments.html#Shell-Arguments) instead of `string-join`