### PR TITLE
Allows `files` argument to be parsed to `ag/search`

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -212,8 +212,9 @@ different window, according to `ag-reuse-window'."
          (mapcar (lambda (item) (list "--ignore" item)) ignores)))
 
 (cl-defun ag/search (string directory
-                            &key (regexp nil) (file-regex nil) (file-type nil))
+                            &key (regexp nil) (file-regex nil) (file-type nil) (files '(".")))
   "Run ag searching for the STRING given in DIRECTORY.
+If `files` is passed, tell ag to look only on those files.
 If REGEXP is non-nil, treat STRING as a regular expression."
   (let ((default-directory (file-name-as-directory directory))
         (arguments ag-arguments)
@@ -248,7 +249,7 @@ If REGEXP is non-nil, treat STRING as a regular expression."
       (error "No such directory %s" default-directory))
     (let ((command-string
            (mapconcat #'shell-quote-argument
-                      (append (list ag-executable) arguments (list string "."))
+                      (append (list ag-executable) arguments (append `(,string) files))
                       " ")))
       ;; If we're called with a prefix, let the user modify the command before
       ;; running it. Typically this means they want to pass additional arguments.


### PR DESCRIPTION
Gives `ag/search` an optional `files` parameter. If parsed, give this
list of files to ag instad of the current directory (".").

I find this usefull because I use org-journal, and now I can do
something like this to search with ag between two dates, for example
2019-15-5->2019-05-31:

```
(let* ((start (org-journal-calendar-date->time '(5 15 2019)))
       (end   (org-journal-calendar-date->time '(5 31 2019)))
       (files (sort (org-journal-search-build-file-list start end) #'string<)))
  (ag/search "foo" "~/Documents/journal" :files files))
```