### PR TITLE
Fix incorrect point placement in minibuffer when prefixed.

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -259,7 +259,7 @@ If REGEXP is non-nil, treat STRING as a regular expression."
         ;; Make a space in the command-string for the user to enter more arguments.
         (setq command-string (ag/replace-first command-string " -- " "  -- "))
         ;; Prompt for the command.
-        (let ((adjusted-point (- (length command-string) (length string) 5)))
+        (let ((adjusted-point (+ 1 (string-match " -- " command-string))))
           (setq command-string
                 (read-from-minibuffer "ag command: "
                                       (cons command-string adjusted-point)))))


### PR DESCRIPTION
Users can prefix an ag-command to pass additional arguments.  If so,
all the arguments will be prompted in the minibuffer for user editing
and point is adjusted to the position for user's input.

However, the calculation of the point position does not take the
backslash (after shell-quote-argument) into account, nor the
variable-length of the `:files' argument.

This commit fixes this issue by searching for " -- " and place the
cursor before it rather than subtracting a fixed value.