### PR TITLE
Travis CI coverage for Emacs 27; Travis CI config uses Nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,45 @@
-language: generic
-sudo: false
+# https://github.com/purcell/nix-emacs-ci
+language: nix
+
+cache:
+  directories:
+  - $HOME/nix.store
+
+jobs:
+  include:
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-24-5
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-25-3
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-3
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-27-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-snapshot
+
 before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
-  - evm install $EVM_EMACS --use --skip
-  - cask
-env:
-  - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-git-snapshot-travis
+  - sudo mkdir -p /etc/nix
+  - echo "substituters = https://cache.nixos.org/ file://$HOME/nix.store" | sudo tee -a /etc/nix/nix.conf > /dev/null
+  - echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
+
+before_cache:
+  - mkdir -p $HOME/nix.store
+  - nix copy --to file://$HOME/nix.store -f default.nix buildInputs
+
+install:
+  # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
+  - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
+  - travis_retry eval $"curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python ; sleep 10"
+  - export PATH=$HOME/.cask/bin:$PATH
+  - travis_retry eval $"cask install ; sleep 10"
 script:
+  - export PATH=$HOME/.cask/bin:$PATH
   - emacs --version
+  - cask build
   - make test
-
-notifications:
-  email: false
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EVM_EMACS=emacs-git-snapshot-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,8 @@ script:
   - emacs --version
   - cask build
   - make test
+
+allow_failures:
+  - os: linux
+    dist: bionic
+    env: EMACS_CI=emacs-snapshot


### PR DESCRIPTION
Uses https://github.com/purcell/nix-emacs-ci now

-  Emacs 24.4 coverage removed; it was failing.  24.5 kept.
- Emacs 26.3 and 27.1 coverage added
- There is no `fast_finish`
- failure allowed on Emacs snapshot, as before