### PR TITLE
Quote arguments to --color-match and --color-path for Powershell

### DIFF
--- a/ag.el
+++ b/ag.el
@@ -225,8 +225,8 @@ If REGEXP is non-nil, treat STRING as a regular expression."
     (unless (equal (car (last arguments)) "--")
       (setq arguments (append arguments '("--"))))
     (setq arguments
-          (append '("--line-number" "--column" "--color" "--color-match" "30;43"
-                    "--color-path" "1;32")
+          (append '("--line-number" "--column" "--color" "--color-match" "\"30;43\""
+                    "--color-path" "\"1;32\"")
                   arguments))
     (if ag-group-matches
         (setq arguments (cons "--group" arguments))


### PR DESCRIPTION
On Windows, when using powershell as the emacs shell, the ag command fails because of the semicolons. Quoting the arguments that contain a semicolon fixes the issue and shouldn't affect any other shell environment.

To reproduce: 

```
Execute this piece of code:
(setq shell-file-name "powershell")

Then run M-x ag anywhere.
```

Results before the fix: 

```
ag --vimgrep --literal --group --line-number --column --color --color-match 30\;43 --color-path 1\;32 --smart-case --stats -- ag/search .
At line:1 char:86
+ ... ine-number --column --color --color-match 30\;43 --color-path 1\;32 - ...
+                                                        ~~~~~~~~~~
Unexpected token 'color-path' in expression or statement.
At line:1 char:105
+ ...  --color --color-match 30\;43 --color-path 1\;32 --smart-case --stats ...
+                                                        ~~~~~~~~~~
Unexpected token 'smart-case' in expression or statement.
At line:1 char:81
+ ... l --group --line-number --column --color --color-match 30\;43 --color ...
+                                                                ~~
The '--' operator works only on variables or on properties.
At line:1 char:100
+ ... mber --column --color --color-match 30\;43 --color-path 1\;32 --smart ...
+                                                                ~~
The '--' operator works only on variables or on properties.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : UnexpectedToken
 
```

Results after the fix:

```
ag --vimgrep --literal --group --line-number --column --color --color-match \"30\;43\" --color-path \"1\;32\" --smart-case --stats -- ag/search .
ag.el:215:11:(cl-defun ag/search (string directory
ag.el:437:4:  (ag/search string directory))
ag.el:449:12:  (apply #'ag/search string directory file-type))
ag.el:458:4:  (ag/search string directory :regexp t))
ag.el:467:4:  (ag/search string (ag/project-root default-directory)))
ag.el:478:11:  (apply 'ag/search string (ag/project-root default-directory) file-type))
ag.el:507:4:  (ag/search regexp (ag/project-root default-directory) :regexp t))
docs/changelog.rst:146:15:API change (``ag/search`` now uses keyword arguments).
docs/changelog.rst:153:57:Note that the *internal API changed* in this release: ``ag/search`` now
9 matches
2 files contained matches
17 files searched
60291 bytes searched
0.026877 seconds
```
